### PR TITLE
Adding DeviceIDOnlyConverter back to build.

### DIFF
--- a/api/api.csproj
+++ b/api/api.csproj
@@ -56,6 +56,7 @@
     <Compile Include="ServerSideAPI.cs" />
     <Compile Include="NullDeviceOutput.cs" />
     <Compile Include="NullDeviceInput.cs" />
+    <Compile Include="DeviceIDOnlyConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />


### PR DESCRIPTION
This fixes the build for everyone on master - somehow the DeviceIDOnlyConverter got dropped from the build.
